### PR TITLE
Adds endpoints, fixes error message and changes AnalyticsDTO

### DIFF
--- a/src/main/java/dto/TwitchAnalyticsDTO.java
+++ b/src/main/java/dto/TwitchAnalyticsDTO.java
@@ -19,7 +19,7 @@ public class TwitchAnalyticsDTO {
     private long views;
     private long followers;
     private Date savedOnDate;
-    private User savedBy;
+    private String savedBy;
 
     public TwitchAnalyticsDTO() {
         savedOnDate = new Date();
@@ -31,7 +31,7 @@ public class TwitchAnalyticsDTO {
         this.views = twitch.getViews();
         this.followers = twitch.getFollowers();
         this.savedOnDate = twitch.getSavedAt();
-        this.savedBy = twitch.getSavedBy();
+        this.savedBy = twitch.getSavedBy().getUserName();
     }
 
     public TwitchAnalyticsDTO(TwitchChannelDTO twitch, Date savedOndate,User savedBy) {
@@ -40,7 +40,7 @@ public class TwitchAnalyticsDTO {
         this.views = twitch.getViews();
         this.followers = twitch.getFollowers();
         this.savedOnDate = savedOndate;
-        this.savedBy = savedBy;
+        this.savedBy = savedBy.getUserName();
     }
 
     public String getId() {
@@ -83,11 +83,11 @@ public class TwitchAnalyticsDTO {
         this.savedOnDate = savedOnDate; 
     }
 
-    public User getSavedBy() {
+    public String getSavedBy() {
         return savedBy;
     }
 
-    public void setSavedBy(User savedBy) {
+    public void setSavedBy(String savedBy) {
         this.savedBy = savedBy;
     }
     

--- a/src/main/java/dto/TwitchAnalyticsDTO.java
+++ b/src/main/java/dto/TwitchAnalyticsDTO.java
@@ -19,7 +19,6 @@ public class TwitchAnalyticsDTO {
     private long views;
     private long followers;
     private Date savedOnDate;
-    private String savedBy;
 
     public TwitchAnalyticsDTO() {
         savedOnDate = new Date();
@@ -31,16 +30,14 @@ public class TwitchAnalyticsDTO {
         this.views = twitch.getViews();
         this.followers = twitch.getFollowers();
         this.savedOnDate = twitch.getSavedAt();
-        this.savedBy = twitch.getSavedBy().getUserName();
     }
 
-    public TwitchAnalyticsDTO(TwitchChannelDTO twitch, Date savedOndate,User savedBy) {
+    public TwitchAnalyticsDTO(TwitchChannelDTO twitch, Date savedOndate) {
         this.id = twitch.getId();
         this.game = twitch.getGame();
         this.views = twitch.getViews();
         this.followers = twitch.getFollowers();
         this.savedOnDate = savedOndate;
-        this.savedBy = savedBy.getUserName();
     }
 
     public String getId() {
@@ -81,16 +78,5 @@ public class TwitchAnalyticsDTO {
 
     public void setSavedOnDate(Date savedOnDate) {
         this.savedOnDate = savedOnDate; 
-    }
-
-    public String getSavedBy() {
-        return savedBy;
-    }
-
-    public void setSavedBy(String savedBy) {
-        this.savedBy = savedBy;
-    }
-    
-    
-    
+    } 
 }

--- a/src/main/java/dto/YouTubeAnalyticsDTO.java
+++ b/src/main/java/dto/YouTubeAnalyticsDTO.java
@@ -19,7 +19,6 @@ public class YouTubeAnalyticsDTO {
     private long subscribers;
     private long videoCount;
     private Date savedOnDate;
-    private String savedBy;
 
     public YouTubeAnalyticsDTO() {
         savedOnDate = new Date();
@@ -31,16 +30,14 @@ public class YouTubeAnalyticsDTO {
         subscribers = yt.getSubscribers();
         videoCount = yt.getVideoCount();
         savedOnDate = yt.getSavedAt();
-        savedBy = yt.getSavedBy().getUserName();
     }
 
-    public YouTubeAnalyticsDTO(YoutubeResultDTO youTubeRes, Date date, User user) {
+    public YouTubeAnalyticsDTO(YoutubeResultDTO youTubeRes, Date date) {
         id = youTubeRes.getId();
         views = youTubeRes.getViews();
         subscribers = youTubeRes.getSubscribers();
         videoCount = youTubeRes.getVideoCount();
         savedOnDate = date;
-        savedBy = user.getUserName();
     }
 
 
@@ -82,14 +79,6 @@ public class YouTubeAnalyticsDTO {
 
     public void setSavedOnDate(Date savedOnDate) {
         this.savedOnDate = savedOnDate; 
-    }
-
-    public String getSavedBy() {
-        return savedBy;
-    }
-
-    public void setSavedBy(String savedBy) {
-        this.savedBy = savedBy;
     }
     
     

--- a/src/main/java/dto/YouTubeAnalyticsDTO.java
+++ b/src/main/java/dto/YouTubeAnalyticsDTO.java
@@ -19,7 +19,7 @@ public class YouTubeAnalyticsDTO {
     private long subscribers;
     private long videoCount;
     private Date savedOnDate;
-    private User savedBy;
+    private String savedBy;
 
     public YouTubeAnalyticsDTO() {
         savedOnDate = new Date();
@@ -31,7 +31,7 @@ public class YouTubeAnalyticsDTO {
         subscribers = yt.getSubscribers();
         videoCount = yt.getVideoCount();
         savedOnDate = yt.getSavedAt();
-        savedBy = yt.getSavedBy();
+        savedBy = yt.getSavedBy().getUserName();
     }
 
     public YouTubeAnalyticsDTO(YoutubeResultDTO youTubeRes, Date date, User user) {
@@ -40,7 +40,7 @@ public class YouTubeAnalyticsDTO {
         subscribers = youTubeRes.getSubscribers();
         videoCount = youTubeRes.getVideoCount();
         savedOnDate = date;
-        savedBy = user;
+        savedBy = user.getUserName();
     }
 
 
@@ -84,11 +84,11 @@ public class YouTubeAnalyticsDTO {
         this.savedOnDate = savedOnDate; 
     }
 
-    public User getSavedBy() {
+    public String getSavedBy() {
         return savedBy;
     }
 
-    public void setSavedBy(User savedBy) {
+    public void setSavedBy(String savedBy) {
         this.savedBy = savedBy;
     }
     

--- a/src/main/java/entities/TwitchAnalytics.java
+++ b/src/main/java/entities/TwitchAnalytics.java
@@ -62,13 +62,13 @@ public class TwitchAnalytics implements Serializable {
     public TwitchAnalytics() {
     }
     
-    public TwitchAnalytics(TwitchAnalyticsDTO twitch, EntityManager em) {
+    public TwitchAnalytics(TwitchAnalyticsDTO twitch, User user) {
         this.channelName = twitch.getId();
         game = twitch.getGame();
         views = twitch.getViews();
         followers = twitch.getFollowers();
         savedAt = twitch.getSavedOnDate();
-        savedBy = em.find(User.class, twitch.getSavedBy());
+        savedBy = user;
     }
 
     

--- a/src/main/java/entities/TwitchAnalytics.java
+++ b/src/main/java/entities/TwitchAnalytics.java
@@ -12,6 +12,7 @@ import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityManager;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -61,13 +62,13 @@ public class TwitchAnalytics implements Serializable {
     public TwitchAnalytics() {
     }
     
-    public TwitchAnalytics(TwitchAnalyticsDTO twitch) {
+    public TwitchAnalytics(TwitchAnalyticsDTO twitch, EntityManager em) {
         this.channelName = twitch.getId();
         game = twitch.getGame();
         views = twitch.getViews();
         followers = twitch.getFollowers();
         savedAt = twitch.getSavedOnDate();
-        savedBy = twitch.getSavedBy();
+        savedBy = em.find(User.class, twitch.getSavedBy());
     }
 
     

--- a/src/main/java/entities/TwitchAnalytics.java
+++ b/src/main/java/entities/TwitchAnalytics.java
@@ -55,20 +55,17 @@ public class TwitchAnalytics implements Serializable {
     private long followers;
     @Temporal(TemporalType.DATE)
     private Date savedAt;
-    @JoinColumn(name = "user_name", referencedColumnName = "user_name")
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
-    private User savedBy;
+
 
     public TwitchAnalytics() {
     }
     
-    public TwitchAnalytics(TwitchAnalyticsDTO twitch, User user) {
+    public TwitchAnalytics(TwitchAnalyticsDTO twitch) {
         this.channelName = twitch.getId();
         game = twitch.getGame();
         views = twitch.getViews();
         followers = twitch.getFollowers();
         savedAt = twitch.getSavedOnDate();
-        savedBy = user;
     }
 
     
@@ -112,14 +109,6 @@ public class TwitchAnalytics implements Serializable {
 
     public void setSavedAt(Date savedAt) {
         this.savedAt = savedAt;
-    }
-
-    public User getSavedBy() {
-        return savedBy;
-    }
-
-    public void setSavedBy(User savedBy) {
-        this.savedBy = savedBy;
     }
     
     

--- a/src/main/java/entities/YouTubeAnalytics.java
+++ b/src/main/java/entities/YouTubeAnalytics.java
@@ -12,6 +12,7 @@ import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityManager;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -61,13 +62,13 @@ public class YouTubeAnalytics implements Serializable {
     public YouTubeAnalytics() {
     }
     
-    public YouTubeAnalytics(YouTubeAnalyticsDTO yt) {
+    public YouTubeAnalytics(YouTubeAnalyticsDTO yt, EntityManager em) {
         this.channelId = yt.getId();
         this.views = yt.getViews();
         this.subscribers = yt.getSubscribers();
         this.videoCount = yt.getVideoCount();
         this.savedAt = yt.getSavedOnDate();
-        this.savedBy = yt.getSavedBy();
+        this.savedBy = em.find(User.class, yt.getSavedBy());
     }
 
     public String getChannelId() {

--- a/src/main/java/entities/YouTubeAnalytics.java
+++ b/src/main/java/entities/YouTubeAnalytics.java
@@ -55,20 +55,16 @@ public class YouTubeAnalytics implements Serializable {
     private long videoCount;
     @Temporal(TemporalType.DATE)
     private Date savedAt;
-    @JoinColumn(name = "user_name", referencedColumnName = "user_name")
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
-    private User savedBy;
 
     public YouTubeAnalytics() {
     }
     
-    public YouTubeAnalytics(YouTubeAnalyticsDTO yt, User user) {
+    public YouTubeAnalytics(YouTubeAnalyticsDTO yt) {
         this.channelId = yt.getId();
         this.views = yt.getViews();
         this.subscribers = yt.getSubscribers();
         this.videoCount = yt.getVideoCount();
         this.savedAt = yt.getSavedOnDate();
-        this.savedBy = user;
     }
 
     public String getChannelId() {
@@ -109,14 +105,6 @@ public class YouTubeAnalytics implements Serializable {
 
     public void setSavedAt(Date savedAt) {
         this.savedAt = savedAt;
-    }
-
-    public User getSavedBy() {
-        return savedBy;
-    }
-
-    public void setSavedBy(User savedBy) {
-        this.savedBy = savedBy;
     }
     
     

--- a/src/main/java/entities/YouTubeAnalytics.java
+++ b/src/main/java/entities/YouTubeAnalytics.java
@@ -62,13 +62,13 @@ public class YouTubeAnalytics implements Serializable {
     public YouTubeAnalytics() {
     }
     
-    public YouTubeAnalytics(YouTubeAnalyticsDTO yt, EntityManager em) {
+    public YouTubeAnalytics(YouTubeAnalyticsDTO yt, User user) {
         this.channelId = yt.getId();
         this.views = yt.getViews();
         this.subscribers = yt.getSubscribers();
         this.videoCount = yt.getVideoCount();
         this.savedAt = yt.getSavedOnDate();
-        this.savedBy = em.find(User.class, yt.getSavedBy());
+        this.savedBy = user;
     }
 
     public String getChannelId() {

--- a/src/main/java/facades/TwitchFacade.java
+++ b/src/main/java/facades/TwitchFacade.java
@@ -114,13 +114,8 @@ public class TwitchFacade {
 
                 TwitchChannelDTO twitchChannelDTO = getTwitchChannel(channelName);
 
-
-                //Temp user
-                User user = em.find(User.class, "user");
-
-
-                TwitchAnalyticsDTO twitchAnalyticsDTO = new TwitchAnalyticsDTO(twitchChannelDTO,new Date(), user);
-                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO, user);
+                TwitchAnalyticsDTO twitchAnalyticsDTO = new TwitchAnalyticsDTO(twitchChannelDTO,new Date());
+                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO);
 
                 try{
                     em.getTransaction().begin();

--- a/src/main/java/facades/TwitchFacade.java
+++ b/src/main/java/facades/TwitchFacade.java
@@ -120,7 +120,7 @@ public class TwitchFacade {
 
 
                 TwitchAnalyticsDTO twitchAnalyticsDTO = new TwitchAnalyticsDTO(twitchChannelDTO,new Date(), user);
-                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO);
+                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO, em);
 
                 try{
                     em.getTransaction().begin();
@@ -147,7 +147,7 @@ public class TwitchFacade {
         });
         
         if (list.isEmpty()) {
-            throw new NotFound("No content found by id " + channelName);
+            throw new NotFound(channelName);
         }
         
         return list;

--- a/src/main/java/facades/TwitchFacade.java
+++ b/src/main/java/facades/TwitchFacade.java
@@ -120,7 +120,7 @@ public class TwitchFacade {
 
 
                 TwitchAnalyticsDTO twitchAnalyticsDTO = new TwitchAnalyticsDTO(twitchChannelDTO,new Date(), user);
-                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO, em);
+                TwitchAnalytics twitchAnalytics = new TwitchAnalytics(twitchAnalyticsDTO, user);
 
                 try{
                     em.getTransaction().begin();

--- a/src/main/java/facades/YoutubeFacade.java
+++ b/src/main/java/facades/YoutubeFacade.java
@@ -154,7 +154,7 @@ public class YoutubeFacade {
 
 
         YouTubeAnalyticsDTO youTubeAnalyticsDTO = new YouTubeAnalyticsDTO(youTubeRes,new Date(), user);
-        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO, em);
+        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO, user);
 
         try{
             em.getTransaction().begin();

--- a/src/main/java/facades/YoutubeFacade.java
+++ b/src/main/java/facades/YoutubeFacade.java
@@ -154,7 +154,7 @@ public class YoutubeFacade {
 
 
         YouTubeAnalyticsDTO youTubeAnalyticsDTO = new YouTubeAnalyticsDTO(youTubeRes,new Date(), user);
-        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO);
+        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO, em);
 
         try{
             em.getTransaction().begin();
@@ -181,7 +181,7 @@ public class YoutubeFacade {
         });
         
         if (list.isEmpty()) {
-            throw new NotFound("No content found by id " + channelId);
+            throw new NotFound(channelId);
         }
         
         return list;

--- a/src/main/java/facades/YoutubeFacade.java
+++ b/src/main/java/facades/YoutubeFacade.java
@@ -149,12 +149,8 @@ public class YoutubeFacade {
         YoutubeResultDTO youTubeRes = getChannelById(id);
         youTubeRes.setId(id);
 
-        //Temp user
-        User user = em.find(User.class, "user");
-
-
-        YouTubeAnalyticsDTO youTubeAnalyticsDTO = new YouTubeAnalyticsDTO(youTubeRes,new Date(), user);
-        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO, user);
+        YouTubeAnalyticsDTO youTubeAnalyticsDTO = new YouTubeAnalyticsDTO(youTubeRes,new Date());
+        YouTubeAnalytics youtubeAnalytics = new YouTubeAnalytics(youTubeAnalyticsDTO);
 
         try{
             em.getTransaction().begin();

--- a/src/main/java/rest/TwitchResource.java
+++ b/src/main/java/rest/TwitchResource.java
@@ -3,6 +3,7 @@ package rest;
         import com.google.gson.Gson;
         import com.google.gson.GsonBuilder;
         import errorhandling.NoResult;
+import errorhandling.NotFound;
         import facades.TwitchFacade;
         import utils.EMF_Creator;
         import facades.YoutubeFacade;
@@ -35,5 +36,13 @@ public class TwitchResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getTwitchChannel(@PathParam("id") String id) throws NoResult {
         return Response.ok().entity(GSON.toJson(FACADE.getTwitchChannel(id))).build();
+    }
+    
+    @Path("get-analytics/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAnalytics(@PathParam("id") String id) throws NotFound {
+        String gson = GSON.toJson(FACADE.getTwitchAnalytics(id));
+        return Response.ok().entity(gson).build();
     }
 }

--- a/src/main/java/rest/YouTubeResource.java
+++ b/src/main/java/rest/YouTubeResource.java
@@ -37,4 +37,12 @@ public class YouTubeResource {
     public Response getChannelInfo(@PathParam("id") String id) throws NotFound{
         return Response.ok().entity(GSON.toJson(FACADE.getChannelById(id))).build();
     }
+    
+    @Path("get-analytics/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAnalytics(@PathParam("id") String id) throws NotFound {
+        String gson = GSON.toJson(FACADE.getYouTubeAnalytics(id));
+        return Response.ok().entity(gson).build();
+    }
 }

--- a/src/main/java/utils/SetupTestAnalytics.java
+++ b/src/main/java/utils/SetupTestAnalytics.java
@@ -24,86 +24,90 @@ public class SetupTestAnalytics {
         setUpYTAnalytics(emf);
         setUpTwitchAnalytics(emf);
     }
-    
+
     public static void setUpYTAnalytics(EntityManagerFactory emf) {
         EntityManager em = emf.createEntityManager();
-        
+
         em.getTransaction().begin();
-        
-        String user = "user";
-        
+
+        String userName = "user";
+
         //YouTube
         YouTubeAnalyticsDTO ytdto1 = new YouTubeAnalyticsDTO();
         YouTubeAnalyticsDTO ytdto2 = new YouTubeAnalyticsDTO();
         YouTubeAnalyticsDTO ytdto3 = new YouTubeAnalyticsDTO();
-        
+
         ytdto1.setId("UC2C_jShtL725hvbm1arSV9w");
         ytdto1.setViews(1012);
         ytdto1.setSubscribers(50);
         ytdto1.setVideoCount(45);
-        ytdto1.setSavedBy(user);
-        
+        ytdto1.setSavedBy(userName);
+
         ytdto2.setId("UC2C_jShtL725hvbm1arSV9w");
         ytdto2.setViews(1102);
         ytdto2.setSubscribers(52);
         ytdto2.setVideoCount(46);
-        ytdto2.setSavedBy(user);
-        
+        ytdto2.setSavedBy(userName);
+
         ytdto3.setId("UC2C_jShtL725hvbm1arSV9w");
         ytdto3.setViews(1150);
         ytdto3.setSubscribers(55);
         ytdto3.setVideoCount(48);
-        ytdto3.setSavedBy(user);
-        
-        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1, em);
-        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2, em);
-        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3, em);
-        
+        ytdto3.setSavedBy(userName);
+
+        User user = em.find(User.class, userName);
+
+        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1, user);
+        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2, user);
+        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3, user);
+
         em.persist(yt1);
         em.persist(yt2);
         em.persist(yt3);
-        
+
         em.getTransaction().commit();
     }
-    
+
     public static void setUpTwitchAnalytics(EntityManagerFactory emf) {
         EntityManager em = emf.createEntityManager();
-        
+
         em.getTransaction().begin();
-        
-        String user = "user";
-        
+
+        String userName = "user";
+
         //Twitch
         TwitchAnalyticsDTO twitchdto1 = new TwitchAnalyticsDTO();
         TwitchAnalyticsDTO twitchdto2 = new TwitchAnalyticsDTO();
         TwitchAnalyticsDTO twitchdto3 = new TwitchAnalyticsDTO();
-        
+
         twitchdto1.setId("sivHD");
         twitchdto1.setViews(1012);
         twitchdto1.setFollowers(50);
         twitchdto1.setGame("Final Fantasy XIV");
-        twitchdto1.setSavedBy(user);
-        
+        twitchdto1.setSavedBy(userName);
+
         twitchdto2.setId("SivHD");
         twitchdto2.setViews(1102);
         twitchdto2.setFollowers(52);
         twitchdto2.setGame("Nier Automata");
-        twitchdto2.setSavedBy(user);
-        
+        twitchdto2.setSavedBy(userName);
+
         twitchdto3.setId("SivHD");
         twitchdto3.setViews(1150);
         twitchdto3.setFollowers(55);
         twitchdto3.setGame("Persona 5: Royal");
-        twitchdto3.setSavedBy(user);
-        
-        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1, em);
-        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2, em);
-        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3, em);
-        
+        twitchdto3.setSavedBy(userName);
+
+        User user = em.find(User.class, userName);
+
+        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1, user);
+        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2, user);
+        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3, user);
+
         em.persist(twitch1);
         em.persist(twitch2);
         em.persist(twitch3);
-        
+
         em.getTransaction().commit();
     }
 }

--- a/src/main/java/utils/SetupTestAnalytics.java
+++ b/src/main/java/utils/SetupTestAnalytics.java
@@ -30,7 +30,7 @@ public class SetupTestAnalytics {
         
         em.getTransaction().begin();
         
-        User user = em.find(User.class, "user");
+        String user = "user";
         
         //YouTube
         YouTubeAnalyticsDTO ytdto1 = new YouTubeAnalyticsDTO();
@@ -55,9 +55,9 @@ public class SetupTestAnalytics {
         ytdto3.setVideoCount(48);
         ytdto3.setSavedBy(user);
         
-        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1);
-        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2);
-        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3);
+        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1, em);
+        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2, em);
+        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3, em);
         
         em.persist(yt1);
         em.persist(yt2);
@@ -71,7 +71,7 @@ public class SetupTestAnalytics {
         
         em.getTransaction().begin();
         
-        User user = em.find(User.class, "user");
+        String user = "user";
         
         //Twitch
         TwitchAnalyticsDTO twitchdto1 = new TwitchAnalyticsDTO();
@@ -96,9 +96,9 @@ public class SetupTestAnalytics {
         twitchdto3.setGame("Persona 5: Royal");
         twitchdto3.setSavedBy(user);
         
-        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1);
-        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2);
-        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3);
+        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1, em);
+        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2, em);
+        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3, em);
         
         em.persist(twitch1);
         em.persist(twitch2);

--- a/src/main/java/utils/SetupTestAnalytics.java
+++ b/src/main/java/utils/SetupTestAnalytics.java
@@ -30,8 +30,6 @@ public class SetupTestAnalytics {
 
         em.getTransaction().begin();
 
-        String userName = "user";
-
         //YouTube
         YouTubeAnalyticsDTO ytdto1 = new YouTubeAnalyticsDTO();
         YouTubeAnalyticsDTO ytdto2 = new YouTubeAnalyticsDTO();
@@ -41,25 +39,20 @@ public class SetupTestAnalytics {
         ytdto1.setViews(1012);
         ytdto1.setSubscribers(50);
         ytdto1.setVideoCount(45);
-        ytdto1.setSavedBy(userName);
 
         ytdto2.setId("UC2C_jShtL725hvbm1arSV9w");
         ytdto2.setViews(1102);
         ytdto2.setSubscribers(52);
         ytdto2.setVideoCount(46);
-        ytdto2.setSavedBy(userName);
 
         ytdto3.setId("UC2C_jShtL725hvbm1arSV9w");
         ytdto3.setViews(1150);
         ytdto3.setSubscribers(55);
         ytdto3.setVideoCount(48);
-        ytdto3.setSavedBy(userName);
 
-        User user = em.find(User.class, userName);
-
-        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1, user);
-        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2, user);
-        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3, user);
+        YouTubeAnalytics yt1 = new YouTubeAnalytics(ytdto1);
+        YouTubeAnalytics yt2 = new YouTubeAnalytics(ytdto2);
+        YouTubeAnalytics yt3 = new YouTubeAnalytics(ytdto3);
 
         em.persist(yt1);
         em.persist(yt2);
@@ -73,8 +66,6 @@ public class SetupTestAnalytics {
 
         em.getTransaction().begin();
 
-        String userName = "user";
-
         //Twitch
         TwitchAnalyticsDTO twitchdto1 = new TwitchAnalyticsDTO();
         TwitchAnalyticsDTO twitchdto2 = new TwitchAnalyticsDTO();
@@ -84,25 +75,20 @@ public class SetupTestAnalytics {
         twitchdto1.setViews(1012);
         twitchdto1.setFollowers(50);
         twitchdto1.setGame("Final Fantasy XIV");
-        twitchdto1.setSavedBy(userName);
 
         twitchdto2.setId("SivHD");
         twitchdto2.setViews(1102);
         twitchdto2.setFollowers(52);
         twitchdto2.setGame("Nier Automata");
-        twitchdto2.setSavedBy(userName);
 
         twitchdto3.setId("SivHD");
         twitchdto3.setViews(1150);
         twitchdto3.setFollowers(55);
         twitchdto3.setGame("Persona 5: Royal");
-        twitchdto3.setSavedBy(userName);
 
-        User user = em.find(User.class, userName);
-
-        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1, user);
-        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2, user);
-        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3, user);
+        TwitchAnalytics twitch1 = new TwitchAnalytics(twitchdto1);
+        TwitchAnalytics twitch2 = new TwitchAnalytics(twitchdto2);
+        TwitchAnalytics twitch3 = new TwitchAnalytics(twitchdto3);
 
         em.persist(twitch1);
         em.persist(twitch2);

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -4,6 +4,10 @@
   <persistence-unit name="pu" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <!--    <class>entities.RenameMe</class>-->
+    <class>entities.Role</class>
+    <class>entities.YouTubeAnalytics</class>
+    <class>entities.User</class>
+    <class>entities.TwitchAnalytics</class>
     <exclude-unlisted-classes>false</exclude-unlisted-classes>
     <properties>
       <!-- DO NOT remove the line below. It's not set by the  entityUtils.EMF_Creator -->
@@ -28,6 +32,10 @@
     <!-- DO NOT RENAME THE PERSISTENCE UNIT -->
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <!--            <class>entities.RenameMe</class>-->
+    <class>entities.Role</class>
+    <class>entities.YouTubeAnalytics</class>
+    <class>entities.TwitchAnalytics</class>
+    <class>entities.User</class>
     <exclude-unlisted-classes>false</exclude-unlisted-classes>
     <properties>
       <property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>

--- a/src/test/java/facades/TwitchFacadeTest.java
+++ b/src/test/java/facades/TwitchFacadeTest.java
@@ -30,7 +30,7 @@ public class TwitchFacadeTest {
     public static void setUpClass() {
         emf = EMF_Creator.createEntityManagerFactoryForTest();
         facade = TwitchFacade.getTwitchFacade(emf);
-                SetupTestAnalytics.setUpTwitchAnalytics(emf);
+        SetupTestAnalytics.setUpTwitchAnalytics(emf);
     }
     
     @AfterAll

--- a/src/test/java/rest/TwitchResourceTest.java
+++ b/src/test/java/rest/TwitchResourceTest.java
@@ -19,6 +19,7 @@ import java.net.URI;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import utils.SetupTestAnalytics;
 //Uncomment the line below, to temporarily disable this test
 //@Disabled
 
@@ -52,7 +53,7 @@ public class TwitchResourceTest {
     @AfterAll
     public static void closeTestServer() {
         //System.in.read();
-
+        
         //Don't forget this, if you called its counterpart in @BeforeAll
         EMF_Creator.endREST_TestWithDB();
         httpServer.shutdownNow();
@@ -74,7 +75,7 @@ public class TwitchResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].id", equalTo("27686136"));
     }
-    
+
     @Test
     public void testSearchTwitchOnName() {
         given()
@@ -84,7 +85,7 @@ public class TwitchResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].name", equalTo("SivHD"));
     }
-    
+
     @Test
     public void testSearchTwitchOnPfpUrl() {
         given()
@@ -94,7 +95,7 @@ public class TwitchResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].profilePicUrl", equalTo("https://static-cdn.jtvnw.net/jtv_user_pictures/a0732bbd-393f-4a16-bbe0-ac10a16b69df-profile_image-300x300.png"));
     }
-    
+
     @Test
     public void testSearchTwitchOnEmptyString() {
         given()
@@ -103,7 +104,7 @@ public class TwitchResourceTest {
                 .assertThat()
                 .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode());
     }
-    
+
     @Test
     public void testSearchTwitchOnNoResults() {
         given()
@@ -113,7 +114,6 @@ public class TwitchResourceTest {
                 .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
                 .body("message", equalTo("No results found for search term 'adhouahgbibeqibf8i2n2'"));
     }
-
 
     @Test
     public void testGetTwitchChannelOnID() {
@@ -153,5 +153,92 @@ public class TwitchResourceTest {
                 .assertThat()
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("game", equalTo("League of Legends"));
+    }
+
+    @Test
+    public void testGetChannelTitle() {
+        String pewDiePieID = "UC-lHJZR3Gqxm24_Vd_AJ5Yw";
+
+        given()
+                .contentType("application/json")
+                .get("/youtube/channel/" + pewDiePieID)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK_200.getStatusCode())
+                .body("title", equalTo("PewDiePie"));
+    }
+
+    @Test
+    public void testGetChannelViews() {
+        String pewDiePieID = "UC-lHJZR3Gqxm24_Vd_AJ5Yw";
+
+        given()
+                .contentType("application/json")
+                .get("/youtube/channel/" + pewDiePieID)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK_200.getStatusCode())
+                .body("country", equalTo("US"));
+    }
+
+    @Test
+    public void testGetChannelTopicCategories() {
+        String pewDiePieID = "UC-lHJZR3Gqxm24_Vd_AJ5Yw";
+
+        given()
+                .contentType("application/json")
+                .get("/youtube/channel/" + pewDiePieID)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK_200.getStatusCode())
+                .body("topicCategories.size()", equalTo(3));
+    }
+
+    @Test
+    public void testGetChannelError() {
+        String wrongId = "";
+
+        given()
+                .contentType("application/json")
+                .get("/youtube/channel/1111")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
+                .body("code", equalTo(404))
+                .body("message", equalTo("No content found by id '1111'"));
+    }
+
+    @Test
+    public void testViewTwitchAnalyticsOnSize() {
+        String id = "SivHD";
+        given()
+                .contentType("application/json")
+                .get("/twitch/get-analytics/" + id)
+                .then().assertThat()
+                .statusCode(HttpStatus.OK_200.getStatusCode())
+                .body("size()", equalTo(3));
+    }
+
+    @Test
+    public void testViewTwitchAnalyticsNoResult() {
+        String id = "hej";
+        given()
+                .contentType("application/json")
+                .get("/twitch/get-analytics/" + id)
+                .then().assertThat()
+                .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
+                .body("code", equalTo(404))
+                .body("message", equalTo("No content found by id 'hej'"));
+    }
+
+    @Test
+    public void testViewTwitchAnalyticsNull() {
+        given()
+                .contentType("application/json")
+                .get("/twitch/get-analytics/")
+                .then().assertThat()
+                .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
+                .body("code", equalTo(404))
+                .body("message", equalTo("HTTP 404 Not Found"));
     }
 }

--- a/src/test/java/rest/TwitchResourceTest.java
+++ b/src/test/java/rest/TwitchResourceTest.java
@@ -242,7 +242,8 @@ public class TwitchResourceTest {
                 .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
                 .body("code", equalTo(404))
                 .body("message", equalTo("HTTP 404 Not Found"));
-
+    }
+    
     @Test
     public void testSaveTwitchChannelOnSize() {
         given()

--- a/src/test/java/rest/TwitchResourceTest.java
+++ b/src/test/java/rest/TwitchResourceTest.java
@@ -212,6 +212,7 @@ public class TwitchResourceTest {
 
     @Test
     public void testViewTwitchAnalyticsOnSize() {
+        SetupTestAnalytics.setUpTwitchAnalytics(emf);
         String id = "SivHD";
         given()
                 .contentType("application/json")

--- a/src/test/java/rest/YouTubeResourceTest.java
+++ b/src/test/java/rest/YouTubeResourceTest.java
@@ -4,7 +4,6 @@ import facades.YoutubeFacade;
 import utils.EMF_Creator;
 import io.restassured.RestAssured;
 import static io.restassured.RestAssured.given;
-
 import io.restassured.parsing.Parser;
 import java.net.URI;
 import javax.persistence.EntityManager;
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import utils.SetupTestAnalytics;
 //Uncomment the line below, to temporarily disable this test
 //@Disabled
 
@@ -66,7 +66,6 @@ public class YouTubeResourceTest {
         EntityManager em = emf.createEntityManager();
     }
 
-    
     @Test
     public void testSearchYouTubeOnID() {
         given()
@@ -76,7 +75,7 @@ public class YouTubeResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].id", equalTo("UC-lHJZR3Gqxm24_Vd_AJ5Yw"));
     }
-    
+
     @Test
     public void testSearchYouTubeOnName() {
         given()
@@ -86,7 +85,7 @@ public class YouTubeResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].name", equalTo("PewDiePie"));
     }
-    
+
     @Test
     public void testSearchYouTubeOnPfpUrl() {
         given()
@@ -96,7 +95,7 @@ public class YouTubeResourceTest {
                 .statusCode(HttpStatus.OK_200.getStatusCode())
                 .body("all[0].profilePicUrl", equalTo("https://yt3.ggpht.com/ytc/AAUvwng76cTETu1glc_8o4UBUiFL2v-m3818ACnK0JLFPA=s800-c-k-c0xffffffff-no-rj-mo"));
     }
-    
+
     @Test
     public void testSearchYouTubeOnEmptyString() {
         given()
@@ -105,7 +104,7 @@ public class YouTubeResourceTest {
                 .assertThat()
                 .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode());
     }
-    
+
     @Test
     public void testSearchYouTubeOnNoResults() {
         given()
@@ -115,6 +114,7 @@ public class YouTubeResourceTest {
                 .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
                 .body("message", equalTo("No results found for search term 'adhou'"));
     }
+
     @Test
     public void testGetChannelTitle() {
         String pewDiePieID = "UC-lHJZR3Gqxm24_Vd_AJ5Yw";
@@ -167,4 +167,39 @@ public class YouTubeResourceTest {
                 .body("code", equalTo(404))
                 .body("message", equalTo("No content found by id '1111'"));
     }
+
+    @Test
+    public void testViewYouTubeAnalyticsOnSize() {
+        String id = "UC2C_jShtL725hvbm1arSV9w";
+        given()
+                .contentType("application/json")
+                .get("/youtube/get-analytics/" + id)
+                .then().assertThat()
+                .statusCode(HttpStatus.OK_200.getStatusCode())
+                .body("size()", equalTo(3));
+    }
+
+    @Test
+    public void testViewYouTubeAnalyticsNoResult() {
+        String id = "hej";
+        given()
+                .contentType("application/json")
+                .get("/youtube/get-analytics/" + id)
+                .then().assertThat()
+                .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
+                .body("code", equalTo(404))
+                .body("message", equalTo("No content found by id 'hej'"));
+    }
+
+    @Test
+    public void testViewYouTubeAnalyticsNull() {
+        given()
+                .contentType("application/json")
+                .get("/youtube/get-analytics/")
+                .then().assertThat()
+                .statusCode(HttpStatus.NOT_FOUND_404.getStatusCode())
+                .body("code", equalTo(404))
+                .body("message", equalTo("HTTP 404 Not Found"));
+    }
+
 }

--- a/src/test/java/rest/YouTubeResourceTest.java
+++ b/src/test/java/rest/YouTubeResourceTest.java
@@ -178,6 +178,7 @@ public class YouTubeResourceTest {
 
     @Test
     public void testViewYouTubeAnalyticsOnSize() {
+        SetupTestAnalytics.setUpYTAnalytics(emf);
         String id = "UC2C_jShtL725hvbm1arSV9w";
         given()
                 .contentType("application/json")


### PR DESCRIPTION
Adds endpoints for getting Twitch and YouTube Analytics
Fixes the error messages for when no result is found, in both Twitch and YouTube Facades
Changes both AnalyticsDTOs to no longer contain a user, but a String with the username
This had ripple effects, and the Analytics entities now find the User through a EntityManager when created from a DTO
